### PR TITLE
fix: use one audioContext instead audio elements

### DIFF
--- a/app/guess-number/GuessNumber.tsx
+++ b/app/guess-number/GuessNumber.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { GuessNumberDialog } from "./GuessNumberDialog";
-import { playVoice } from "./voice";
+import { VoiceText, playVoice } from "./voice";
 import { useReducer, useRef, useState } from "react";
 import styles from "./GuessNumber.module.css";
 
@@ -16,6 +16,11 @@ export const GuessNumber = () => {
   const [resetKey, updateResetKey] = useReducer((prev: number) => prev + 1, 0);
   const [serif, setSerif] = useState<string>("あそぶ？❤");
   const [count, setCount] = useState(0);
+  const audio = useRef(typeof Audio !== "undefined" ? new Audio() : null);
+
+  const play = (text: VoiceText) => {
+    playVoice(audio?.current, text);
+  };
 
   return (
     <div className={styles.root}>
@@ -47,7 +52,7 @@ export const GuessNumber = () => {
             setTime(0);
             setCount(0);
             setCorrectNumber(
-              numbers[Math.floor(Math.random() * numbers.length)]
+              numbers[Math.floor(Math.random() * numbers.length)],
             );
             updateResetKey();
             setSerif("数字をえらんで❤");
@@ -91,16 +96,16 @@ export const GuessNumber = () => {
                     setIsStarted(false);
                     if (time < 5) {
                       setSerif("すっご～い❤");
-                      playVoice("すっごーい");
+                      play("すっごーい");
                     } else if (time < 8) {
                       setSerif("がんばれ❤がんばれ❤");
-                      playVoice("がんばれがんばれ");
+                      play("がんばれがんばれ");
                     } else if (time < 20) {
                       setSerif("ざぁこ❤");
-                      playVoice("ざあこ");
+                      play("ざあこ");
                     } else {
                       setSerif("なっさけな〜い❤");
-                      playVoice("なっさけない");
+                      play("なっさけない");
                     }
                   } else {
                     if (correctNumber === undefined) {
@@ -108,17 +113,17 @@ export const GuessNumber = () => {
                     }
                     if (count > 2) {
                       setSerif("ざぁこ❤ざぁこ❤");
-                      playVoice("ざあこざあこ");
+                      play("ざあこざあこ");
                       setIsStarted(false);
                       if (timer.current !== null) {
                         window.clearInterval(timer.current);
                       }
                     } else if (number < correctNumber) {
                       setSerif("ちっさ❤");
-                      playVoice("ちっさ");
+                      play("ちっさ");
                     } else {
                       setSerif("でっか❤");
-                      playVoice("でっか");
+                      play("でっか");
                     }
                     setCount((prev) => prev + 1);
                   }

--- a/app/guess-number/GuessNumber.tsx
+++ b/app/guess-number/GuessNumber.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { GuessNumberDialog } from "./GuessNumberDialog";
-import { VoiceText, playVoice, voiceList } from "./voice";
+import { playVoice } from "./voice";
 import { useReducer, useRef, useState } from "react";
 import styles from "./GuessNumber.module.css";
 
@@ -17,27 +17,8 @@ export const GuessNumber = () => {
   const [serif, setSerif] = useState<string>("あそぶ？❤");
   const [count, setCount] = useState(0);
 
-  const prevAudio = useRef<HTMLAudioElement | null>(null);
-
-  const play = (text: VoiceText) => {
-    /**
-     * iOSで、他のaudioが再生されている最中に別のaudioを再生しようとすると、それ以降そのaudioが生成されなくなるような挙動をする。
-     * 詳しい原因は不明。
-     */
-    if (prevAudio.current !== null) {
-      prevAudio.current.pause();
-    }
-    const audio = playVoice(text);
-    prevAudio.current = audio;
-  };
-
   return (
     <div className={styles.root}>
-      <div>
-        {voiceList.map(({ src, text }) => {
-          return <audio key={src} src={src} id={`audio-${text}`} />;
-        })}
-      </div>
       <GuessNumberDialog />
       <div>
         <a
@@ -66,7 +47,7 @@ export const GuessNumber = () => {
             setTime(0);
             setCount(0);
             setCorrectNumber(
-              numbers[Math.floor(Math.random() * numbers.length)],
+              numbers[Math.floor(Math.random() * numbers.length)]
             );
             updateResetKey();
             setSerif("数字をえらんで❤");
@@ -110,16 +91,16 @@ export const GuessNumber = () => {
                     setIsStarted(false);
                     if (time < 5) {
                       setSerif("すっご～い❤");
-                      play("すっごーい");
+                      playVoice("すっごーい");
                     } else if (time < 8) {
                       setSerif("がんばれ❤がんばれ❤");
-                      play("がんばれがんばれ");
+                      playVoice("がんばれがんばれ");
                     } else if (time < 20) {
                       setSerif("ざぁこ❤");
-                      play("ざあこ");
+                      playVoice("ざあこ");
                     } else {
                       setSerif("なっさけな〜い❤");
-                      play("なっさけない");
+                      playVoice("なっさけない");
                     }
                   } else {
                     if (correctNumber === undefined) {
@@ -127,17 +108,17 @@ export const GuessNumber = () => {
                     }
                     if (count > 2) {
                       setSerif("ざぁこ❤ざぁこ❤");
-                      play("ざあこざあこ");
+                      playVoice("ざあこざあこ");
                       setIsStarted(false);
                       if (timer.current !== null) {
                         window.clearInterval(timer.current);
                       }
                     } else if (number < correctNumber) {
                       setSerif("ちっさ❤");
-                      play("ちっさ");
+                      playVoice("ちっさ");
                     } else {
                       setSerif("でっか❤");
-                      play("でっか");
+                      playVoice("でっか");
                     }
                     setCount((prev) => prev + 1);
                   }

--- a/app/guess-number/GuessNumberDialog.tsx
+++ b/app/guess-number/GuessNumberDialog.tsx
@@ -41,7 +41,8 @@ export const GuessNumberDialog = () => {
         className={styles.OverlayButton}
         onClick={() => {
           setIsPlaying(true);
-          const audio = playVoice("タイトルコール");
+          const audio = new Audio();
+          playVoice(audio, "タイトルコール");
 
           audio.onended = () => {
             dialogRef.current?.close();

--- a/app/guess-number/voice.ts
+++ b/app/guess-number/voice.ts
@@ -1,4 +1,4 @@
-export const voiceList = [
+const voiceList = [
   { src: "/mesugaki/title.mp3", text: "タイトルコール" },
   { src: "/mesugaki/がんばれがんばれ.mp3", text: "がんばれがんばれ" },
   { src: "/mesugaki/ざあこ.mp3", text: "ざあこ" },
@@ -9,12 +9,13 @@ export const voiceList = [
   { src: "/mesugaki/なっさけない.mp3", text: "なっさけない" },
 ] as const;
 
-export type VoiceText = (typeof voiceList)[number]["text"];
+type VoiceText = (typeof voiceList)[number]["text"];
+
+const audio = new Audio();
 
 export const playVoice = (text: VoiceText) => {
-  const audio = document.getElementById(`audio-${text}`) as HTMLAudioElement;
+  audio.src = voiceList.find((voice) => voice.text === text)?.src ?? "";
 
-  audio.currentTime = 0;
   void audio.play();
 
   return audio;

--- a/app/guess-number/voice.ts
+++ b/app/guess-number/voice.ts
@@ -1,22 +1,21 @@
-const voiceList = [
-  { src: "/mesugaki/title.mp3", text: "タイトルコール" },
-  { src: "/mesugaki/がんばれがんばれ.mp3", text: "がんばれがんばれ" },
-  { src: "/mesugaki/ざあこ.mp3", text: "ざあこ" },
-  { src: "/mesugaki/ざあこざあこ.mp3", text: "ざあこざあこ" },
-  { src: "/mesugaki/すっごーい.mp3", text: "すっごーい" },
-  { src: "/mesugaki/ちっさ.mp3", text: "ちっさ" },
-  { src: "/mesugaki/でっか.mp3", text: "でっか" },
-  { src: "/mesugaki/なっさけない.mp3", text: "なっさけない" },
-] as const;
+export const voiceMap = {
+  タイトルコール: { src: "/mesugaki/title.mp3" },
+  がんばれがんばれ: { src: "/mesugaki/がんばれがんばれ.mp3" },
+  ざあこ: { src: "/mesugaki/ざあこ.mp3" },
+  ざあこざあこ: { src: "/mesugaki/ざあこざあこ.mp3" },
+  すっごーい: { src: "/mesugaki/すっごーい.mp3" },
+  ちっさ: { src: "/mesugaki/ちっさ.mp3" },
+  でっか: { src: "/mesugaki/でっか.mp3" },
+  なっさけない: { src: "/mesugaki/なっさけない.mp3" },
+};
 
-type VoiceText = (typeof voiceList)[number]["text"];
+export type VoiceText = keyof typeof voiceMap;
 
-const audio = new Audio();
-
-export const playVoice = (text: VoiceText) => {
-  audio.src = voiceList.find((voice) => voice.text === text)?.src ?? "";
+export const playVoice = (audio: HTMLAudioElement | null, text: VoiceText) => {
+  if (!audio) {
+    return;
+  }
+  audio.src = voiceMap[text].src;
 
   void audio.play();
-
-  return audio;
 };


### PR DESCRIPTION
## Why

- しばらく利用していると、iOS、正確にはSafariで特定の音声が聞こえなくなる現象があった。
- audio要素を入れる形式であったため、controls属性を与えて様子を見ると、なぜか音声ファイルの長さが0になる挙動が確認できた。ソースが消えているわけではなく、audio要素を直接操作すると再生される。ただし再生してもmetadataは復旧しない。
- この挙動は、再生を抑制することで軽減できることが確認できたが、結局回数を重ねると発生した。

## What

- audio要素を利用するのをやめ、単一のAudioを使い回すようにコードを変更したところ発生が確認できなくなった。