### PR TITLE
Apply React Best Practices (Performance & Rendering)

### DIFF
--- a/app/games/mochinoa-jump/page.tsx
+++ b/app/games/mochinoa-jump/page.tsx
@@ -116,10 +116,16 @@ export default function MochinoaJump() {
 		[isPlaying, gameOver, startGame, resetGame, jump],
 	);
 
+	const handleKeyPressRef = useRef(handleKeyPress);
 	useEffect(() => {
-		window.addEventListener("keydown", handleKeyPress);
-		return () => window.removeEventListener("keydown", handleKeyPress);
+		handleKeyPressRef.current = handleKeyPress;
 	}, [handleKeyPress]);
+
+	useEffect(() => {
+		const handler = (e: KeyboardEvent) => handleKeyPressRef.current(e);
+		window.addEventListener("keydown", handler);
+		return () => window.removeEventListener("keydown", handler);
+	}, []);
 
 	// スコアに基づいて障害物の間隔を計算
 	const getObstacleInterval = useCallback(() => {

--- a/app/guess-number/GuessNumberDialog.tsx
+++ b/app/guess-number/GuessNumberDialog.tsx
@@ -4,6 +4,26 @@ import { useRef, useState } from "react";
 import styles from "./GuessNumberDialog.module.css";
 import { playVoice } from "./voice";
 
+const VolumeIcon = (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		width="24"
+		height="24"
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="2"
+		strokeLinecap="round"
+		strokeLinejoin="round"
+		className={styles.LargeIcon}
+	>
+		<title>音量アイコン</title>
+		<path d="M11.536 14.01A8.473 8.473 0 0 0 14.026 8a8.473 8.473 0 0 0-2.49-6.01l-.708.707A7.476 7.476 0 0 1 13.025 8c0 2.071-.84 3.946-2.197 5.303l.708.707z" />
+		<path d="M10.121 12.596A6.48 6.48 0 0 0 12.025 8a6.48 6.48 0 0 0-1.904-4.596l-.707.707A5.483 5.483 0 0 1 11.025 8a5.483 5.483 0 0 1-1.61 3.89l.706.706z" />
+		<path d="M8.707 11.182A4.486 4.486 0 0 0 10.025 8a4.486 4.486 0 0 0-1.318-3.182L8 5.525A3.489 3.489 0 0 1 9.025 8 3.49 3.49 0 0 1 8 10.475l.707.707zM6.717 3.55A.5.5 0 0 1 7 4v8a.5.5 0 0 1-.812.39L3.825 10.5H1.5A.5.5 0 0 1 1 10V6a.5.5 0 0 1 .5-.5h2.325l2.363-1.89a.5.5 0 0 1 .529-.06z" />
+	</svg>
+);
+
 export const GuessNumberDialog = () => {
 	const dialogRef = useRef<HTMLDialogElement | null>(null);
 	const [isPlaying, setIsPlaying] = useState(false);
@@ -18,23 +38,7 @@ export const GuessNumberDialog = () => {
 			}}
 		>
 			<div>
-				<svg
-					xmlns="http://www.w3.org/2000/svg"
-					width="24"
-					height="24"
-					viewBox="0 0 24 24"
-					fill="none"
-					stroke="currentColor"
-					strokeWidth="2"
-					strokeLinecap="round"
-					strokeLinejoin="round"
-					className={styles.LargeIcon}
-				>
-					<title>音量アイコン</title>
-					<path d="M11.536 14.01A8.473 8.473 0 0 0 14.026 8a8.473 8.473 0 0 0-2.49-6.01l-.708.707A7.476 7.476 0 0 1 13.025 8c0 2.071-.84 3.946-2.197 5.303l.708.707z" />
-					<path d="M10.121 12.596A6.48 6.48 0 0 0 12.025 8a6.48 6.48 0 0 0-1.904-4.596l-.707.707A5.483 5.483 0 0 1 11.025 8a5.483 5.483 0 0 1-1.61 3.89l.706.706z" />
-					<path d="M8.707 11.182A4.486 4.486 0 0 0 10.025 8a4.486 4.486 0 0 0-1.318-3.182L8 5.525A3.489 3.489 0 0 1 9.025 8 3.49 3.49 0 0 1 8 10.475l.707.707zM6.717 3.55A.5.5 0 0 1 7 4v8a.5.5 0 0 1-.812.39L3.825 10.5H1.5A.5.5 0 0 1 1 10V6a.5.5 0 0 1 .5-.5h2.325l2.363-1.89a.5.5 0 0 1 .529-.06z" />
-				</svg>
+				{VolumeIcon}
 			</div>
 			<p>
 				このサイトでは、ゲームを始めると音声が流れます。

--- a/app/guess-number/GuessNumberDialog.tsx
+++ b/app/guess-number/GuessNumberDialog.tsx
@@ -37,9 +37,7 @@ export const GuessNumberDialog = () => {
 				}
 			}}
 		>
-			<div>
-				{VolumeIcon}
-			</div>
+			<div>{VolumeIcon}</div>
 			<p>
 				このサイトでは、ゲームを始めると音声が流れます。
 				スピーカーなどの音量にご注意ください。

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Applied two React performance best practices according to guidelines:
1. **Hoist Static JSX Elements:** Extracted the static SVG icon from `GuessNumberDialog` to avoid object recreation on re-renders.
2. **Store Event Handlers in Refs:** Stored the `handleKeyPress` callback in a ref so the `useEffect` doesn't constantly add/remove event listeners on state changes.

---
*PR created automatically by Jules for task [9573264020437865458](https://jules.google.com/task/9573264020437865458) started by @hrdtbs*