### PR TITLE
Refactor: Cache repeated function calls in TypingGame

### DIFF
--- a/app/games/typing/page.tsx
+++ b/app/games/typing/page.tsx
@@ -243,6 +243,8 @@ export default function TypingGame() {
 		);
 	};
 
+	const currentResultMessage = gameOver ? getResultMessage(totalChars) : null;
+
 	return (
 		<div className={styles.container}>
 			<h1 className={styles.title}>もちのあタイピング</h1>
@@ -262,7 +264,7 @@ export default function TypingGame() {
 						</button>
 						<p className={styles.keyHint}>スペースキーでもスタートできます</p>
 					</>
-				) : gameOver ? (
+				) : gameOver && currentResultMessage ? (
 					<div className={styles.result}>
 						<div className={styles.resultContent}>
 							<div className={styles.resultText}>
@@ -272,7 +274,7 @@ export default function TypingGame() {
 								<p>ミス回数: {missCount}回</p>
 								<p>1分間の入力速度: {totalChars}文字/分</p>
 								<div className={styles.resultMessage}>
-									<p>{getResultMessage(totalChars).message}</p>
+									<p>{currentResultMessage.message}</p>
 								</div>
 								<button
 									type="button"
@@ -289,11 +291,11 @@ export default function TypingGame() {
 									Xでシェア
 								</button>
 							</div>
-							{getResultMessage(totalChars).image !== null ? (
+							{currentResultMessage.image !== null ? (
 								<div className={styles.resultImage}>
 									<Image
 										src={
-											getResultMessage(totalChars).image ??
+											currentResultMessage.image ??
 											"/images/default.jpg"
 										}
 										alt="結果画像"

--- a/app/games/typing/page.tsx
+++ b/app/games/typing/page.tsx
@@ -294,10 +294,7 @@ export default function TypingGame() {
 							{currentResultMessage.image !== null ? (
 								<div className={styles.resultImage}>
 									<Image
-										src={
-											currentResultMessage.image ??
-											"/images/default.jpg"
-										}
+										src={currentResultMessage.image ?? "/images/default.jpg"}
 										alt="結果画像"
 										width={600}
 										height={400}


### PR DESCRIPTION
Identified and applied the "Cache Repeated Function Calls" pattern from the local repository skills and Next.js/React best practices. Specifically, the `getResultMessage` function in `app/games/typing/page.tsx` was being repeatedly called with the same argument (`totalChars`) three times during the render phase. Extracted this into a single variable assignment, avoiding redundant computations and deduplicating code. Build, linting, and typechecks have successfully passed.

---
*PR created automatically by Jules for task [7668963553188161155](https://jules.google.com/task/7668963553188161155) started by @hrdtbs*