### PR TITLE
refactor: initialize migration once in useCollection

### DIFF
--- a/app/gacha/useCollection.tsx
+++ b/app/gacha/useCollection.tsx
@@ -108,6 +108,8 @@ export const useDispatchCollection = () => {
 	return context;
 };
 
+let didInitMigration = false;
+
 interface CollectionProviderProps {
 	children: React.ReactNode;
 }
@@ -120,32 +122,35 @@ export const CollectionProvider = ({ children }: CollectionProviderProps) => {
 	const [ticketLogs, setTicketLogs] = useState<TicketLog[]>([]);
 
 	useEffect(() => {
-		// Try to migrate old unversioned data first
-		try {
-			const oldTicketsStr = localStorage.getItem("mcgc_ticket");
-			if (oldTicketsStr) {
-				const oldTickets = Number.parseInt(oldTicketsStr, 10);
-				if (!Number.isNaN(oldTickets)) {
-					saveToStorage(TICKET_KEY, oldTickets);
+		if (!didInitMigration) {
+			didInitMigration = true;
+			// Try to migrate old unversioned data first
+			try {
+				const oldTicketsStr = localStorage.getItem("mcgc_ticket");
+				if (oldTicketsStr) {
+					const oldTickets = Number.parseInt(oldTicketsStr, 10);
+					if (!Number.isNaN(oldTickets)) {
+						saveToStorage(TICKET_KEY, oldTickets);
+					}
+					localStorage.removeItem("mcgc_ticket");
 				}
-				localStorage.removeItem("mcgc_ticket");
-			}
 
-			const oldCollectionStr = localStorage.getItem("mcgc");
-			if (oldCollectionStr) {
-				const oldCollection = JSON.parse(oldCollectionStr);
-				saveToStorage(COLLECTION_KEY, oldCollection);
-				localStorage.removeItem("mcgc");
-			}
+				const oldCollectionStr = localStorage.getItem("mcgc");
+				if (oldCollectionStr) {
+					const oldCollection = JSON.parse(oldCollectionStr);
+					saveToStorage(COLLECTION_KEY, oldCollection);
+					localStorage.removeItem("mcgc");
+				}
 
-			const oldLogsStr = localStorage.getItem("mcgc_ticket_log");
-			if (oldLogsStr) {
-				const oldLogs = JSON.parse(oldLogsStr);
-				saveToStorage(TICKEY_LOG_KEY, oldLogs);
-				localStorage.removeItem("mcgc_ticket_log");
+				const oldLogsStr = localStorage.getItem("mcgc_ticket_log");
+				if (oldLogsStr) {
+					const oldLogs = JSON.parse(oldLogsStr);
+					saveToStorage(TICKEY_LOG_KEY, oldLogs);
+					localStorage.removeItem("mcgc_ticket_log");
+				}
+			} catch {
+				// Ignore migration errors
 			}
-		} catch {
-			// Ignore migration errors
 		}
 
 		setCollection(loadFromStorage<[number, number][]>(COLLECTION_KEY, []));


### PR DESCRIPTION
`app/gacha/useCollection.tsx` にて、マウント毎に走っていた古いローカルストレージのマイグレーション処理を、アプリケーションの読み込み時に一度だけ実行されるように、モジュールスコープのフラグ (`didInitMigration`) を使って修正しました。

これは `.agents/skills/vercel-react-best-practices/rules/advanced-init-once.md` に記載されている「Initialize App Once, Not Per Mount」のベストプラクティスに従ったリファクタリングです。

---
*PR created automatically by Jules for task [315293056220961240](https://jules.google.com/task/315293056220961240) started by @hrdtbs*