### PR TITLE
refactor: apply nextjs and react best practices

### DIFF
--- a/app/games/typing/page.tsx
+++ b/app/games/typing/page.tsx
@@ -264,7 +264,7 @@ export default function TypingGame() {
 						</button>
 						<p className={styles.keyHint}>スペースキーでもスタートできます</p>
 					</>
-				) : gameOver && currentResultMessage ? (
+				) : gameOver && currentResultMessage !== null ? (
 					<div className={styles.result}>
 						<div className={styles.resultContent}>
 							<div className={styles.resultText}>

--- a/features/top/MusicGallery/MusicGallery.tsx
+++ b/features/top/MusicGallery/MusicGallery.tsx
@@ -3,7 +3,7 @@
 import clsx from "clsx";
 import { AnimatePresence, motion } from "motion/react";
 import Image from "next/image";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import tag1Img from "../../../app/_assets/images/タグ1.png";
 import type { Song } from "../../../app/_site.config";
 import styles from "./MusicGallery.module.css";
@@ -119,7 +119,7 @@ export function MusicGallery({ songs }: Props) {
 		setSelectedIndex(index);
 	}, []);
 
-	const tripled = useMemo(() => [...songs, ...songs, ...songs], [songs]);
+	const tripled = [...songs, ...songs, ...songs];
 	const selected = songs[selectedIndex];
 
 	return (


### PR DESCRIPTION
This refactor addresses some identified anti-patterns based on Next.js/React best practices documented in `.agents/skills`:

1.  **Conditional Rendering**: Updated `app/games/typing/page.tsx` to use explicit null checks instead of short-circuit `&&` evaluations. This follows the `rendering-conditional-render` best practice, which prevents potential UI bugs where `0` or `NaN` might be accidentally rendered.
2.  **Memoization**: Removed an unnecessary `useMemo` from `features/top/MusicGallery/MusicGallery.tsx`. The operation being memoized was a simple array spread (`[...songs, ...songs, ...songs]`), which is computationally cheap. Using `useMemo` here adds unnecessary overhead (dependency tracking, memory allocation) that outweighs the cost of recreation, in line with the `rerender-simple-expression-in-memo` best practice.

The project builds successfully and passes lint checks.

---
*PR created automatically by Jules for task [6544983208874512328](https://jules.google.com/task/6544983208874512328) started by @hrdtbs*