### PR TITLE
Refactor: optimize initial bundle with next/dynamic imports

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,15 +1,40 @@
 import dynamic from "next/dynamic";
-import { BannerSection } from "../features/top/BannerSection/BannerSection";
-import { ContactSection } from "../features/top/ContactSection/ContactSection";
 import { HeroSection } from "../features/top/HeroSection/HeroSection";
-import { MusicGallery } from "../features/top/MusicGallery/MusicGallery";
 import { PortraitSection } from "../features/top/PortraitSection/PortraitSection";
-import { ProfileSection } from "../features/top/ProfileSection/ProfileSection";
-import { ShopSection } from "../features/top/ShopSection/ShopSection";
 import { SideNav } from "../features/top/SideNav/SideNav";
 import { siteConfig } from "./_site.config";
 import "../styles/page.global.css";
 import styles from "./page.module.css";
+
+const ProfileSection = dynamic(() =>
+	import("../features/top/ProfileSection/ProfileSection").then(
+		(mod) => mod.ProfileSection,
+	),
+);
+
+const MusicGallery = dynamic(() =>
+	import("../features/top/MusicGallery/MusicGallery").then(
+		(mod) => mod.MusicGallery,
+	),
+);
+
+const ShopSection = dynamic(() =>
+	import("../features/top/ShopSection/ShopSection").then(
+		(mod) => mod.ShopSection,
+	),
+);
+
+const BannerSection = dynamic(() =>
+	import("../features/top/BannerSection/BannerSection").then(
+		(mod) => mod.BannerSection,
+	),
+);
+
+const ContactSection = dynamic(() =>
+	import("../features/top/ContactSection/ContactSection").then(
+		(mod) => mod.ContactSection,
+	),
+);
 
 const WAVE_W = 1000;
 const WAVE_ARC_DEPTH = 60;


### PR DESCRIPTION
This PR applies the `bundle-dynamic-imports` Vercel React best practice by refactoring the `app/page.tsx` page to lazy load "below the fold" components using `next/dynamic`.

This optimization significantly decreases the initial JavaScript bundle size, improving Time To Interactive (TTI) without causing LCP regressions since the HeroSection is still loaded statically.

---
*PR created automatically by Jules for task [15856866662037704738](https://jules.google.com/task/15856866662037704738) started by @hrdtbs*