### PR TITLE
Refactor: Derive `gameOver` state in typing game

### DIFF
--- a/app/games/typing/page.tsx
+++ b/app/games/typing/page.tsx
@@ -132,10 +132,11 @@ export default function TypingGame() {
 	const [timeLeft, setTimeLeft] = useState(60);
 	const [totalChars, setTotalChars] = useState(0);
 	const [correctWords, setCorrectWords] = useState(0);
-	const [gameOver, setGameOver] = useState(false);
 	const [missCount, setMissCount] = useState(0);
 	const audioRef = useRef<HTMLAudioElement | null>(null);
 	const inputRef = useRef<HTMLInputElement | null>(null);
+
+	const gameOver = !isPlaying && timeLeft === 0;
 
 	useEffect(() => {
 		audioRef.current = new Audio("/sounds/miss.mp3");
@@ -143,7 +144,6 @@ export default function TypingGame() {
 
 	const startGame = useCallback(() => {
 		setIsPlaying(true);
-		setGameOver(false);
 		setTimeLeft(60);
 		setTotalChars(0);
 		setCorrectWords(0);
@@ -180,7 +180,6 @@ export default function TypingGame() {
 
 	const resetGame = useCallback(() => {
 		setIsPlaying(false);
-		setGameOver(false);
 		setTimeLeft(60);
 		setTotalChars(0);
 		setCorrectWords(0);
@@ -196,7 +195,6 @@ export default function TypingGame() {
 				setTimeLeft((prev) => {
 					if (prev <= 1) {
 						setIsPlaying(false);
-						setGameOver(true);
 						return 0;
 					}
 					return prev - 1;


### PR DESCRIPTION
This commit removes the redundant `gameOver` state and its corresponding updater. It derives the `gameOver` variable dynamically during rendering from existing `isPlaying` and `timeLeft` state, preventing stale state loops and avoiding setting a state inside another functional update, aligning with the "Calculate Derived State During Rendering" Vercel React Best Practice.

---
*PR created automatically by Jules for task [2490872579500160960](https://jules.google.com/task/2490872579500160960) started by @hrdtbs*