### PR TITLE
Refactor: Cache function results for generateAllPatterns

### DIFF
--- a/app/games/typing/page.tsx
+++ b/app/games/typing/page.tsx
@@ -93,6 +93,18 @@ const generateAllPatterns = (romaji: string): string[] => {
 	return [...new Set(patterns)]; // 重複を除去
 };
 
+const patternsCache = new Map<string, string[]>();
+
+const cachedGenerateAllPatterns = (romaji: string): string[] => {
+	const cached = patternsCache.get(romaji);
+	if (cached) {
+		return cached;
+	}
+	const result = generateAllPatterns(romaji);
+	patternsCache.set(romaji, result);
+	return result;
+};
+
 const getResultMessage = (chars: number): ResultMessage => {
 	if (chars >= 200) {
 		return {
@@ -116,7 +128,7 @@ export default function TypingGame() {
 	const [text, setText] = useState("");
 	const possiblePatterns = useMemo(() => {
 		const romajiText = toRomaji(text);
-		const patterns = generateAllPatterns(romajiText);
+		const patterns = cachedGenerateAllPatterns(romajiText);
 
 		const prefixSet = new Set<string>();
 		for (const pattern of patterns) {


### PR DESCRIPTION
Refactored `app/games/typing/page.tsx` to cache the results of the `generateAllPatterns` function to prevent redundant computations on identical inputs, aligning with the "Cache Repeated Function Calls" React best practice.

---
*PR created automatically by Jules for task [15115371778487543909](https://jules.google.com/task/15115371778487543909) started by @hrdtbs*