### PR TITLE
Refactor `useCollection` to use functional `setCollection` update

### DIFF
--- a/app/gacha/useCollection.tsx
+++ b/app/gacha/useCollection.tsx
@@ -212,14 +212,16 @@ export const CollectionProvider = ({ children }: CollectionProviderProps) => {
 								const rare = rate < 0.6 ? 3 : rate < 0.1 ? 2 : 1;
 								const index = shuffled.findIndex((item) => item.rare === rare);
 
-								const collectionMap = new Map(collection);
-								const count = collectionMap.get(index) ?? 0;
-								collectionMap.set(index, count + 1);
-								const next: [number, number][] = Array.from(
-									collectionMap.entries(),
-								);
-								saveToStorage(COLLECTION_KEY, next);
-								setCollection(next);
+								setCollection((prevCollection) => {
+									const collectionMap = new Map(prevCollection);
+									const count = collectionMap.get(index) ?? 0;
+									collectionMap.set(index, count + 1);
+									const next: [number, number][] = Array.from(
+										collectionMap.entries(),
+									);
+									saveToStorage(COLLECTION_KEY, next);
+									return next;
+								});
 
 								return data[index];
 							},


### PR DESCRIPTION
Refactored the `setCollection` call inside `draw` function in `app/gacha/useCollection.tsx` to use the functional update form instead of referencing the outer `collection` state directly. This adheres to the `rerender-functional-setstate.md` React best practice.

---
*PR created automatically by Jules for task [10027565888213109647](https://jules.google.com/task/10027565888213109647) started by @hrdtbs*