### PR TITLE
Refactor: Apply React Best Practices to Game Components

### DIFF
--- a/app/games/slide-puzzle/components/GameBoard.tsx
+++ b/app/games/slide-puzzle/components/GameBoard.tsx
@@ -80,27 +80,28 @@ export default function GameBoard() {
 		const emptyIndex = board.indexOf(difficulty === "easy" ? 8 : 15);
 		const movableIndices = getMovableIndices(emptyIndex, difficulty);
 
-		if (movableIndices.includes(index)) {
-			const newBoard = [...board];
-			[newBoard[emptyIndex], newBoard[index]] = [
-				newBoard[index],
-				newBoard[emptyIndex],
-			];
-			setBoard(newBoard);
-			setMoves((prev) => prev + 1);
+		// BEST PRACTICE: Early Return from Functions (7.8)
+		if (!movableIndices.includes(index)) return;
 
-			// 状態更新後に完成チェックを実行
-			const isCompleted = newBoard.every((value, idx) => value === idx);
-			if (isCompleted) {
-				const finalTime = Date.now() - (startTimeRef.current ?? 0);
-				setTimeout(() => {
-					router.push(
-						`/games/slide-puzzle/complete?time=${finalTime}&moves=${
-							moves + 1
-						}&difficulty=${difficulty}`,
-					);
-				}, 500);
-			}
+		const newBoard = [...board];
+		[newBoard[emptyIndex], newBoard[index]] = [
+			newBoard[index],
+			newBoard[emptyIndex],
+		];
+		setBoard(newBoard);
+		setMoves((prev) => prev + 1);
+
+		// 状態更新後に完成チェックを実行
+		const isCompleted = newBoard.every((value, idx) => value === idx);
+		if (isCompleted) {
+			const finalTime = Date.now() - (startTimeRef.current ?? 0);
+			setTimeout(() => {
+				router.push(
+					`/games/slide-puzzle/complete?time=${finalTime}&moves=${
+						moves + 1
+					}&difficulty=${difficulty}`,
+				);
+			}, 500);
 		}
 	};
 

--- a/app/games/typing/page.tsx
+++ b/app/games/typing/page.tsx
@@ -158,7 +158,10 @@ export default function TypingGame() {
 	const gameOver = !isPlaying && timeLeft === 0;
 
 	useEffect(() => {
-		audioRef.current = new Audio("/sounds/miss.mp3");
+		// BEST PRACTICE: Initialize App Once, Not Per Mount (8.1)
+		if (!audioRef.current) {
+			audioRef.current = new Audio("/sounds/miss.mp3");
+		}
 	}, []);
 
 	const startGame = useCallback(() => {


### PR DESCRIPTION
I reviewed the Vercel React Best Practices document and refactored the codebase to align with the guidelines.

Specifically:
- Applied "7.8 Early Return from Functions" to the `moveTile` function in `app/games/slide-puzzle/components/GameBoard.tsx` to flatten the logic and make it more readable.
- Applied "8.1 Initialize App Once, Not Per Mount" to the `useEffect` hook in `app/games/typing/page.tsx` to prevent the `Audio` object from being redundantly instantiated multiple times during component mount/remount in React 18's Strict Mode.

I also initially attempted to apply "5.10 Use Lazy State Initialization" to the `board` state in `GameBoard.tsx`, but testing and code review revealed that it introduced a React hydration mismatch since the state initialization relied on a random value (`shuffleBoard`). Therefore, I reverted that part to maintain SSR stability while keeping the other safe refactors intact.

All changes have been successfully checked with the local type checking and linting processes (`pnpm run typecheck` and `pnpm run lint`), and `pnpm run build` completed successfully without any errors.

---
*PR created automatically by Jules for task [1056211263469930](https://jules.google.com/task/1056211263469930) started by @hrdtbs*