### PR TITLE
Add sizes prop to Image with fill in nyantomo page

### DIFF
--- a/app/games/nyantomo/page.tsx
+++ b/app/games/nyantomo/page.tsx
@@ -64,6 +64,7 @@ function Page() {
 					src="/nyantomo/heroImage.jpg"
 					alt="hero image"
 					fill
+					sizes="100vw"
 					className={styles.heroImage}
 				/>
 			</section>


### PR DESCRIPTION
This commit refactors the `Image` component in `app/games/nyantomo/page.tsx`. By adding the `sizes="100vw"` attribute to the image with `fill`, it adheres to the "Image Optimization" Next.js best practice specified in `.agents/skills/next-best-practices/image.md`.

---
*PR created automatically by Jules for task [4495506020676410617](https://jules.google.com/task/4495506020676410617) started by @hrdtbs*