### PR TITLE
Refactor to optimize layout thrashing using CSS transforms

### DIFF
--- a/app/games/mochinoa-jump/page.module.css
+++ b/app/games/mochinoa-jump/page.module.css
@@ -70,6 +70,7 @@
 .obstacle {
 	position: absolute;
 	bottom: 0;
+	left: 0;
 	background-color: #ffd8d8;
 	border-radius: 4px;
 }

--- a/app/games/mochinoa-jump/page.tsx
+++ b/app/games/mochinoa-jump/page.tsx
@@ -228,7 +228,7 @@ export default function MochinoaJump() {
 		for (const obstacle of obstaclesRef.current) {
 			const div = document.createElement("div");
 			div.className = `${styles.obstacle} ${styles[obstacle.type]}`;
-			div.style.left = `${obstacle.x}px`;
+			div.style.transform = `translateX(${obstacle.x}px)`;
 			div.style.width = `${obstacle.width}px`;
 			div.style.height = `${obstacle.height}px`;
 			container.appendChild(div);

--- a/components/CursorSparkles/CursorSparkles.module.css
+++ b/components/CursorSparkles/CursorSparkles.module.css
@@ -17,10 +17,12 @@
 @keyframes sparkle-fade {
 	0% {
 		opacity: 1;
-		transform: translate(calc(var(--tx) - 50%), calc(var(--ty) - 50%)) scale(1) rotate(0deg);
+		transform: translate(calc(var(--tx) - 50%), calc(var(--ty) - 50%)) scale(1)
+			rotate(0deg);
 	}
 	100% {
 		opacity: 0;
-		transform: translate(calc(var(--tx) - 50%), calc(var(--ty) - 50% - 40px)) scale(0) rotate(120deg);
+		transform: translate(calc(var(--tx) - 50%), calc(var(--ty) - 50% - 40px))
+			scale(0) rotate(120deg);
 	}
 }

--- a/components/CursorSparkles/CursorSparkles.module.css
+++ b/components/CursorSparkles/CursorSparkles.module.css
@@ -8,6 +8,8 @@
 
 .sparkle {
 	position: fixed;
+	left: 0;
+	top: 0;
 	pointer-events: none;
 	animation: sparkle-fade 800ms ease-out forwards;
 }
@@ -15,10 +17,10 @@
 @keyframes sparkle-fade {
 	0% {
 		opacity: 1;
-		transform: translate(-50%, -50%) scale(1) rotate(0deg);
+		transform: translate(calc(var(--tx) - 50%), calc(var(--ty) - 50%)) scale(1) rotate(0deg);
 	}
 	100% {
 		opacity: 0;
-		transform: translate(-50%, calc(-50% - 40px)) scale(0) rotate(120deg);
+		transform: translate(calc(var(--tx) - 50%), calc(var(--ty) - 50% - 40px)) scale(0) rotate(120deg);
 	}
 }

--- a/components/CursorSparkles/CursorSparkles.tsx
+++ b/components/CursorSparkles/CursorSparkles.tsx
@@ -44,8 +44,8 @@ export function CursorSparkles() {
 
 			sparkle.innerHTML = STAR_SVG;
 			sparkle.className = styles.sparkle;
-			sparkle.style.left = `${e.clientX + offsetX}px`;
-			sparkle.style.top = `${e.clientY + offsetY}px`;
+			sparkle.style.setProperty("--tx", `${e.clientX + offsetX}px`);
+			sparkle.style.setProperty("--ty", `${e.clientY + offsetY}px`);
 			sparkle.style.width = `${size}px`;
 			sparkle.style.height = `${size}px`;
 			sparkle.style.color = color;


### PR DESCRIPTION
Refactored components to improve performance by avoiding layout thrashing. This is achieved by utilizing `transform` instead of `left` and `top` properties for animation and positioning. The changes affect the `CursorSparkles` component and the Mochinoa Jump game's obstacle rendering.

---
*PR created automatically by Jules for task [3568806630066297341](https://jules.google.com/task/3568806630066297341) started by @hrdtbs*