### PR TITLE
refactor: hoist static jsx element in GuessNumber component

### DIFF
--- a/app/guess-number/GuessNumber.tsx
+++ b/app/guess-number/GuessNumber.tsx
@@ -9,6 +9,19 @@ const numbers = [
 	1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
 ];
 
+const avatarImage = (
+	<div>
+		<Image
+			src="/mesugaki/dummy.webp"
+			alt="望月のあ"
+			height={200}
+			width={200}
+			style={{ objectFit: "contain" }}
+			className={styles.Avatar}
+		/>
+	</div>
+);
+
 export const GuessNumber = () => {
 	const timeRef = useRef(0);
 	const timerDisplayRef = useRef<HTMLDivElement>(null);
@@ -80,16 +93,7 @@ export const GuessNumber = () => {
 			>
 				{serif}
 			</button>
-			<div>
-				<Image
-					src="/mesugaki/dummy.webp"
-					alt="望月のあ"
-					height={200}
-					width={200}
-					style={{ objectFit: "contain" }}
-					className={styles.Avatar}
-				/>
-			</div>
+			{avatarImage}
 			<div className={styles.NumbersGroup}>
 				{numbers.map((number) => (
 					<label key={number} className={styles.Number}>


### PR DESCRIPTION
Extracted the static `avatarImage` JSX element out of the `GuessNumber` component to prevent it from being unnecessarily recreated on every render. This follows the `.agents/skills/vercel-react-best-practices/rules/rendering-hoist-jsx.md` best practice guidelines.

---
*PR created automatically by Jules for task [6113373393199611770](https://jules.google.com/task/6113373393199611770) started by @hrdtbs*