### PR TITLE
refactor: apply Vercel advanced event handler best practices

### DIFF
--- a/app/games/mochinoa-jump/page.tsx
+++ b/app/games/mochinoa-jump/page.tsx
@@ -2,12 +2,7 @@
 
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import {
-	useCallback,
-	useEffect,
-	useRef,
-	useState,
-} from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import styles from "./page.module.css";
 
 interface Obstacle {

--- a/app/games/mochinoa-jump/page.tsx
+++ b/app/games/mochinoa-jump/page.tsx
@@ -5,7 +5,6 @@ import { useRouter } from "next/navigation";
 import {
 	useCallback,
 	useEffect,
-	useEffectEvent,
 	useRef,
 	useState,
 } from "react";
@@ -125,11 +124,15 @@ export default function MochinoaJump() {
 		[isPlaying, gameOver, startGame, resetGame, jump],
 	);
 
-	const onKeyPressEvent = useEffectEvent(handleKeyPress);
+	const handleKeyPressRef = useRef(handleKeyPress);
+	useEffect(() => {
+		handleKeyPressRef.current = handleKeyPress;
+	}, [handleKeyPress]);
 
 	useEffect(() => {
-		window.addEventListener("keydown", onKeyPressEvent);
-		return () => window.removeEventListener("keydown", onKeyPressEvent);
+		const listener = (e: KeyboardEvent) => handleKeyPressRef.current(e);
+		window.addEventListener("keydown", listener);
+		return () => window.removeEventListener("keydown", listener);
 	}, []);
 
 	// スコアに基づいて障害物の間隔を計算

--- a/app/games/typing/page.tsx
+++ b/app/games/typing/page.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import {
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toRomaji } from "wanakana";
 import styles from "./page.module.css";
 

--- a/app/games/typing/page.tsx
+++ b/app/games/typing/page.tsx
@@ -4,7 +4,6 @@ import Image from "next/image";
 import {
 	useCallback,
 	useEffect,
-	useEffectEvent,
 	useMemo,
 	useRef,
 	useState,
@@ -189,11 +188,15 @@ export default function TypingGame() {
 		[isPlaying, gameOver, startGame],
 	);
 
-	const onKeyPressEvent = useEffectEvent(handleKeyPress);
+	const handleKeyPressRef = useRef(handleKeyPress);
+	useEffect(() => {
+		handleKeyPressRef.current = handleKeyPress;
+	}, [handleKeyPress]);
 
 	useEffect(() => {
-		window.addEventListener("keydown", onKeyPressEvent);
-		return () => window.removeEventListener("keydown", onKeyPressEvent);
+		const listener = (e: KeyboardEvent) => handleKeyPressRef.current(e);
+		window.addEventListener("keydown", listener);
+		return () => window.removeEventListener("keydown", listener);
 	}, []);
 
 	const resetGame = useCallback(() => {


### PR DESCRIPTION
This PR refactors the usage of the experimental `useEffectEvent` API. Following the `advanced-event-handler-refs.md` Vercel best practice, I've replaced `useEffectEvent` with a `useRef` + `useEffect` pattern to ensure stable event handlers without depending on experimental React APIs. 

Changes:
- Removed `useEffectEvent` import and usages.
- Implemented `handleKeyPressRef` pattern in `app/games/typing/page.tsx`.
- Implemented `handleKeyPressRef` pattern in `app/games/mochinoa-jump/page.tsx`.

---
*PR created automatically by Jules for task [5986086104973004870](https://jules.google.com/task/5986086104973004870) started by @hrdtbs*