### PR TITLE
✂️ Prune: @types/react-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
 		"@biomejs/biome": "2.5.0",
 		"@types/node": "22.19.21",
 		"@types/react": "19.2.17",
-		"@types/react-dom": "19.2.3",
 		"typescript": "6.0.3"
 	},
 	"pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,9 +42,6 @@ importers:
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17
-      '@types/react-dom':
-        specifier: 19.2.3
-        version: 19.2.3(@types/react@19.2.17)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -330,11 +327,6 @@ packages:
 
   '@types/node@22.19.21':
     resolution: {integrity: sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==}
-
-  '@types/react-dom@19.2.3':
-    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
-    peerDependencies:
-      '@types/react': ^19.2.0
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
@@ -667,10 +659,6 @@ snapshots:
   '@types/node@22.19.21':
     dependencies:
       undici-types: 6.21.0
-
-  '@types/react-dom@19.2.3(@types/react@19.2.17)':
-    dependencies:
-      '@types/react': 19.2.17
 
   '@types/react@19.2.17':
     dependencies:


### PR DESCRIPTION
Removed `@types/react-dom` as it was flagged as an unused devDependency by `knip`. Verified that `pnpm build`, `pnpm run typecheck`, and `pnpm run lint` still succeed.

---
*PR created automatically by Jules for task [6279171658886557016](https://jules.google.com/task/6279171658886557016) started by @hrdtbs*