### PR TITLE
Refactor event handlers to use useEffectEvent

### DIFF
--- a/app/games/mochinoa-jump/page.tsx
+++ b/app/games/mochinoa-jump/page.tsx
@@ -2,7 +2,13 @@
 
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+	useCallback,
+	useEffect,
+	useEffectEvent,
+	useRef,
+	useState,
+} from "react";
 import styles from "./page.module.css";
 
 interface Obstacle {
@@ -103,31 +109,22 @@ export default function MochinoaJump() {
 	}, [startGame]);
 
 	// キーボードイベントの処理
-	const handleKeyPress = useCallback(
-		(e: KeyboardEvent) => {
-			if (e.code === "Space") {
-				if (!isPlaying) {
-					startGame();
-				} else if (gameOver) {
-					resetGame();
-				} else if (!isJumpingRef.current) {
-					// ジャンプ中でない場合のみジャンプを実行
-					jump();
-				}
+	const onKeyPressEvent = useEffectEvent((e: KeyboardEvent) => {
+		if (e.code === "Space") {
+			if (!isPlaying) {
+				startGame();
+			} else if (gameOver) {
+				resetGame();
+			} else if (!isJumpingRef.current) {
+				// ジャンプ中でない場合のみジャンプを実行
+				jump();
 			}
-		},
-		[isPlaying, gameOver, startGame, resetGame, jump],
-	);
-
-	const handleKeyPressRef = useRef(handleKeyPress);
-	useEffect(() => {
-		handleKeyPressRef.current = handleKeyPress;
-	}, [handleKeyPress]);
+		}
+	});
 
 	useEffect(() => {
-		const listener = (e: KeyboardEvent) => handleKeyPressRef.current(e);
-		window.addEventListener("keydown", listener);
-		return () => window.removeEventListener("keydown", listener);
+		window.addEventListener("keydown", onKeyPressEvent);
+		return () => window.removeEventListener("keydown", onKeyPressEvent);
 	}, []);
 
 	// スコアに基づいて障害物の間隔を計算

--- a/app/games/typing/page.tsx
+++ b/app/games/typing/page.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import Image from "next/image";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+	useCallback,
+	useEffect,
+	useEffectEvent,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { toRomaji } from "wanakana";
 import styles from "./page.module.css";
 
@@ -172,25 +179,16 @@ export default function TypingGame() {
 	}, []);
 
 	// キーボードイベントのハンドラー
-	const handleKeyPress = useCallback(
-		(e: KeyboardEvent) => {
-			if (!isPlaying && !gameOver && e.code === "Space") {
-				e.preventDefault();
-				startGame();
-			}
-		},
-		[isPlaying, gameOver, startGame],
-	);
-
-	const handleKeyPressRef = useRef(handleKeyPress);
-	useEffect(() => {
-		handleKeyPressRef.current = handleKeyPress;
-	}, [handleKeyPress]);
+	const onKeyPressEvent = useEffectEvent((e: KeyboardEvent) => {
+		if (!isPlaying && !gameOver && e.code === "Space") {
+			e.preventDefault();
+			startGame();
+		}
+	});
 
 	useEffect(() => {
-		const listener = (e: KeyboardEvent) => handleKeyPressRef.current(e);
-		window.addEventListener("keydown", listener);
-		return () => window.removeEventListener("keydown", listener);
+		window.addEventListener("keydown", onKeyPressEvent);
+		return () => window.removeEventListener("keydown", onKeyPressEvent);
 	}, []);
 
 	const resetGame = useCallback(() => {


### PR DESCRIPTION
- Replaced `useRef` + `useEffect` combo with `useEffectEvent` in `app/games/typing/page.tsx`
- Replaced `useRef` + `useEffect` combo with `useEffectEvent` in `app/games/mochinoa-jump/page.tsx`
- Both changes ensure that keyboard event handlers always have access to the latest state without re-registering event listeners.

---
*PR created automatically by Jules for task [15922283960576280497](https://jules.google.com/task/15922283960576280497) started by @hrdtbs*