### PR TITLE
Refactor: replace next/dynamic with standard imports in app/page.tsx

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,40 +1,15 @@
-import dynamic from "next/dynamic";
+import { CursorSparkles } from "../components/CursorSparkles/CursorSparkles";
+import { BannerSection } from "../features/top/BannerSection/BannerSection";
+import { ContactSection } from "../features/top/ContactSection/ContactSection";
 import { HeroSection } from "../features/top/HeroSection/HeroSection";
+import { MusicGallery } from "../features/top/MusicGallery/MusicGallery";
 import { PortraitSection } from "../features/top/PortraitSection/PortraitSection";
+import { ProfileSection } from "../features/top/ProfileSection/ProfileSection";
+import { ShopSection } from "../features/top/ShopSection/ShopSection";
 import { SideNav } from "../features/top/SideNav/SideNav";
 import { siteConfig } from "./_site.config";
 import "../styles/page.global.css";
 import styles from "./page.module.css";
-
-const ProfileSection = dynamic(() =>
-	import("../features/top/ProfileSection/ProfileSection").then(
-		(mod) => mod.ProfileSection,
-	),
-);
-
-const MusicGallery = dynamic(() =>
-	import("../features/top/MusicGallery/MusicGallery").then(
-		(mod) => mod.MusicGallery,
-	),
-);
-
-const ShopSection = dynamic(() =>
-	import("../features/top/ShopSection/ShopSection").then(
-		(mod) => mod.ShopSection,
-	),
-);
-
-const BannerSection = dynamic(() =>
-	import("../features/top/BannerSection/BannerSection").then(
-		(mod) => mod.BannerSection,
-	),
-);
-
-const ContactSection = dynamic(() =>
-	import("../features/top/ContactSection/ContactSection").then(
-		(mod) => mod.ContactSection,
-	),
-);
 
 const WAVE_W = 1000;
 const WAVE_ARC_DEPTH = 60;
@@ -87,12 +62,6 @@ const waveSvg = (
 	>
 		<path d={wavePath.d} fill="#63bac7" />
 	</svg>
-);
-
-const CursorSparkles = dynamic(() =>
-	import("../components/CursorSparkles/CursorSparkles").then(
-		(mod) => mod.CursorSparkles,
-	),
 );
 
 export default function Page() {


### PR DESCRIPTION
Replaced `next/dynamic` imports with standard imports in `app/page.tsx` for layout and static components (`ProfileSection`, `MusicGallery`, `ShopSection`, `BannerSection`, `ContactSection`, `CursorSparkles`). This adheres to the Next.js bundle-dynamic-imports best practice, which advises only using `dynamic` for heavy components that are not needed on initial render, as overusing it can create unnecessary chunks and hurt initial load performance.

---
*PR created automatically by Jules for task [13748983758767702501](https://jules.google.com/task/13748983758767702501) started by @hrdtbs*