### PR TITLE
perf: optimize MusicGallery import using next/dynamic

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,21 @@
+import dynamic from "next/dynamic";
 import { CursorSparkles } from "../components/CursorSparkles/CursorSparkles";
 import { BannerSection } from "../features/top/BannerSection/BannerSection";
 import { ContactSection } from "../features/top/ContactSection/ContactSection";
 import { HeroSection } from "../features/top/HeroSection/HeroSection";
-import { MusicGallery } from "../features/top/MusicGallery/MusicGallery";
 import { PortraitSection } from "../features/top/PortraitSection/PortraitSection";
 import { ProfileSection } from "../features/top/ProfileSection/ProfileSection";
 import { ShopSection } from "../features/top/ShopSection/ShopSection";
 import { SideNav } from "../features/top/SideNav/SideNav";
 import { siteConfig } from "./_site.config";
+
+// BEST PRACTICE: Dynamic Imports for Heavy Components (bundle-dynamic-imports.md)
+const MusicGallery = dynamic(() =>
+	import("../features/top/MusicGallery/MusicGallery").then(
+		(mod) => mod.MusicGallery,
+	),
+);
+
 import "../styles/page.global.css";
 import styles from "./page.module.css";
 


### PR DESCRIPTION
In `app/page.tsx`, the `MusicGallery` component was imported statically, which included heavy libraries such as `motion/react` in the initial bundle. Following the `bundle-dynamic-imports.md` best practice (Dynamic Imports for Heavy Components), I changed the import to a dynamic import (`next/dynamic`) to reduce the initial load time and improve Time to Interactive.

---
*PR created automatically by Jules for task [7710133929425592913](https://jules.google.com/task/7710133929425592913) started by @hrdtbs*