### PR TITLE
Refactor to apply Next.js / React best practices

### DIFF
--- a/app/games/slide-puzzle/components/GameBoard.tsx
+++ b/app/games/slide-puzzle/components/GameBoard.tsx
@@ -68,10 +68,13 @@ export default function GameBoard() {
 	}, []);
 
 	// 初期化
-	// biome-ignore lint/correctness/useExhaustiveDependencies: Initialize only on mount
+	// BEST PRACTICE: Initialize App Once, Not Per Mount (advanced-init-once.md)
+	const didInitRef = useRef(false);
 	useEffect(() => {
+		if (didInitRef.current) return;
+		didInitRef.current = true;
 		initializeBoard(difficulty);
-	}, []);
+	}, [initializeBoard, difficulty]);
 
 	// タイルを移動
 	const moveTile = (index: number) => {


### PR DESCRIPTION
Applied Next.js / React best practices to the codebase based on the guidelines in `.agents/skills/vercel-react-best-practices/`.

Specifically, `app/games/slide-puzzle/components/GameBoard.tsx` was refactored. The `useEffect` for board initialization previously lacked proper dependencies and bypassed linting with a `// biome-ignore` comment.
By applying the `advanced-init-once.md` best practice concept, a `didInitRef` uses `useRef(false)` to ensure initialization only triggers once upon mount without suppressing exhaustive-deps errors.

This ensures proper adherence to exhaustive dependencies while safely tracking initialization.

---
*PR created automatically by Jules for task [4118090218135997828](https://jules.google.com/task/4118090218135997828) started by @hrdtbs*