### PR TITLE
chore(renovate): TypeScript major 更新を一時抑止

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,5 +15,13 @@
 	"lockFileMaintenance": {
 		"enabled": true,
 		"schedule": ["before 9am on the first day of the month"]
-	}
+	},
+	"packageRules": [
+		{
+			"description": "TypeScript 7 drops the JS Compiler API; Next.js stable (16.2.x) does not support it yet. Re-enable when Next.js ships experimental.useTypeScriptCli (or equivalent) on latest.",
+			"matchPackageNames": ["typescript"],
+			"matchUpdateTypes": ["major"],
+			"enabled": false
+		}
+	]
 }


### PR DESCRIPTION
## Summary
- #667（typescript 7.0.2）は Next.js 16.2.10 と非互換で Vercel ビルドが失敗するためクローズ済み
- TypeScript 7 は JS Compiler API を同梱せず、Next.js が誤検知してクラッシュする
- Next.js stable が TS 7 をサポートするまで、Renovate の typescript major 更新を無効化

## Test plan
- [ ] Renovate が `typescript` の major 更新 PR を新規作成しないこと
- [ ] 既存の patch/minor 依存更新には影響しないこと

Refs: https://github.com/vercel/next.js/issues/95400, https://github.com/vercel/next.js/discussions/95633