### PR TITLE
refactor: apply Vercel React Best Practices

### DIFF
--- a/app/games/mochinoa-jump/page.tsx
+++ b/app/games/mochinoa-jump/page.tsx
@@ -9,6 +9,7 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { useGlobalKeydown } from "../../../components/hooks/useGlobalKeydown";
 import styles from "./page.module.css";
 
 interface Obstacle {
@@ -122,10 +123,7 @@ export default function MochinoaJump() {
 		}
 	});
 
-	useEffect(() => {
-		window.addEventListener("keydown", onKeyPressEvent);
-		return () => window.removeEventListener("keydown", onKeyPressEvent);
-	}, []);
+	useGlobalKeydown(onKeyPressEvent);
 
 	// スコアに基づいて障害物の間隔を計算
 	const getObstacleInterval = useCallback(() => {

--- a/app/games/typing/page.tsx
+++ b/app/games/typing/page.tsx
@@ -10,6 +10,7 @@ import {
 	useState,
 } from "react";
 import { toRomaji } from "wanakana";
+import { useGlobalKeydown } from "../../../components/hooks/useGlobalKeydown";
 import styles from "./page.module.css";
 
 interface ResultMessage {
@@ -189,10 +190,7 @@ export default function TypingGame() {
 		}
 	});
 
-	useEffect(() => {
-		window.addEventListener("keydown", onKeyPressEvent);
-		return () => window.removeEventListener("keydown", onKeyPressEvent);
-	}, []);
+	useGlobalKeydown(onKeyPressEvent);
 
 	const resetGame = useCallback(() => {
 		setIsPlaying(false);

--- a/app/guess-number/GuessNumberDialog.tsx
+++ b/app/guess-number/GuessNumberDialog.tsx
@@ -1,4 +1,4 @@
-"ues client";
+"use client";
 
 import { useRef, useState } from "react";
 import styles from "./GuessNumberDialog.module.css";

--- a/app/prs/6th-anniversary-revenue-report/ImageModal.tsx
+++ b/app/prs/6th-anniversary-revenue-report/ImageModal.tsx
@@ -5,6 +5,7 @@ import { AnimatePresence, motion } from "motion/react";
 import type { StaticImageData } from "next/image";
 import Image from "next/image";
 import { useCallback, useEffect, useEffectEvent, useState } from "react";
+import { useGlobalKeydown } from "../../../components/hooks/useGlobalKeydown";
 import styles from "./page.module.css";
 
 interface ImageModalProps {
@@ -17,20 +18,6 @@ const zoomInIconLarge = <ZoomIn size={32} />;
 const zoomInIconSmall = <ZoomIn size={20} />;
 const zoomOutIconSmall = <ZoomOut size={20} />;
 const closeIcon = <X size={24} />;
-
-// BEST PRACTICE: Deduplicate Global Event Listeners (client-event-listeners.md)
-const keydownCallbacks = new Set<(e: KeyboardEvent) => void>();
-let isGlobalKeydownListenerAdded = false;
-
-function addGlobalKeydownListener() {
-	if (typeof window === "undefined" || isGlobalKeydownListenerAdded) return;
-	window.addEventListener("keydown", (e: KeyboardEvent) => {
-		for (const cb of keydownCallbacks) {
-			cb(e);
-		}
-	});
-	isGlobalKeydownListenerAdded = true;
-}
 
 export function ImageModal({ src, alt }: ImageModalProps) {
 	const [isOpen, setIsOpen] = useState(false);
@@ -51,11 +38,10 @@ export function ImageModal({ src, alt }: ImageModalProps) {
 		if (e.key === "Escape") closeModal();
 	});
 
+	useGlobalKeydown(onEscEvent);
+
 	useEffect(() => {
-		addGlobalKeydownListener();
-		keydownCallbacks.add(onEscEvent);
 		return () => {
-			keydownCallbacks.delete(onEscEvent);
 			document.body.style.overflow = "unset";
 		};
 	}, []);

--- a/components/hooks/useGlobalKeydown.ts
+++ b/components/hooks/useGlobalKeydown.ts
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+
+// Deduplicate global event listeners for keyboard events
+
+const keydownCallbacks = new Set<(e: KeyboardEvent) => void>();
+let isGlobalKeydownListenerAdded = false;
+
+function addGlobalKeydownListener() {
+	if (typeof window === "undefined" || isGlobalKeydownListenerAdded) return;
+	window.addEventListener("keydown", (e: KeyboardEvent) => {
+		for (const cb of keydownCallbacks) {
+			cb(e);
+		}
+	});
+	isGlobalKeydownListenerAdded = true;
+}
+
+export function useGlobalKeydown(callback: (e: KeyboardEvent) => void) {
+	useEffect(() => {
+		addGlobalKeydownListener();
+		keydownCallbacks.add(callback);
+		return () => {
+			keydownCallbacks.delete(callback);
+		};
+	}, [callback]);
+}


### PR DESCRIPTION
- Extracted global `keydown` event listener logic into a deduplicated `useGlobalKeydown` custom hook based on the `client-event-listeners.md` best practice.
- Applied `useGlobalKeydown` hook to `app/prs/6th-anniversary-revenue-report/ImageModal.tsx`, `app/games/typing/page.tsx`, and `app/games/mochinoa-jump/page.tsx`, replacing multiple `window.addEventListener` instances with a single global listener.
- Fixed typo `"ues client"` to `"use client"` in `app/guess-number/GuessNumberDialog.tsx`.

---
*PR created automatically by Jules for task [10435869382525796785](https://jules.google.com/task/10435869382525796785) started by @hrdtbs*