### PR TITLE
refactor: apply client-event-listeners best practice

### DIFF
--- a/app/prs/6th-anniversary-revenue-report/ImageModal.tsx
+++ b/app/prs/6th-anniversary-revenue-report/ImageModal.tsx
@@ -4,7 +4,8 @@ import { X, ZoomIn, ZoomOut } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import type { StaticImageData } from "next/image";
 import Image from "next/image";
-import { useCallback, useEffect, useEffectEvent, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import useSWRSubscription from "swr/subscription";
 import styles from "./page.module.css";
 
 interface ImageModalProps {
@@ -19,17 +20,37 @@ const zoomOutIconSmall = <ZoomOut size={20} />;
 const closeIcon = <X size={24} />;
 
 // BEST PRACTICE: Deduplicate Global Event Listeners (client-event-listeners.md)
-const keydownCallbacks = new Set<(e: KeyboardEvent) => void>();
-let isGlobalKeydownListenerAdded = false;
+const keyCallbacks = new Map<string, Set<() => void>>();
 
-function addGlobalKeydownListener() {
-	if (typeof window === "undefined" || isGlobalKeydownListenerAdded) return;
-	window.addEventListener("keydown", (e: KeyboardEvent) => {
-		for (const cb of keydownCallbacks) {
-			cb(e);
+function useKeyboardShortcut(key: string, callback: () => void) {
+	useEffect(() => {
+		if (!keyCallbacks.has(key)) {
+			keyCallbacks.set(key, new Set());
 		}
+		keyCallbacks.get(key)?.add(callback);
+
+		return () => {
+			const set = keyCallbacks.get(key);
+			if (set) {
+				set.delete(callback);
+				if (set.size === 0) {
+					keyCallbacks.delete(key);
+				}
+			}
+		};
+	}, [key, callback]);
+
+	useSWRSubscription("global-keydown", () => {
+		const handler = (e: KeyboardEvent) => {
+			if (keyCallbacks.has(e.key)) {
+				keyCallbacks.get(e.key)?.forEach((cb) => {
+					cb();
+				});
+			}
+		};
+		window.addEventListener("keydown", handler);
+		return () => window.removeEventListener("keydown", handler);
 	});
-	isGlobalKeydownListenerAdded = true;
 }
 
 export function ImageModal({ src, alt }: ImageModalProps) {
@@ -47,15 +68,10 @@ export function ImageModal({ src, alt }: ImageModalProps) {
 		document.body.style.overflow = "unset";
 	}, []);
 
-	const onEscEvent = useEffectEvent((e: KeyboardEvent) => {
-		if (e.key === "Escape") closeModal();
-	});
+	useKeyboardShortcut("Escape", closeModal);
 
 	useEffect(() => {
-		addGlobalKeydownListener();
-		keydownCallbacks.add(onEscEvent);
 		return () => {
-			keydownCallbacks.delete(onEscEvent);
 			document.body.style.overflow = "unset";
 		};
 	}, []);

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"next": "16.2.10",
 		"react": "19.2.7",
 		"react-dom": "19.2.7",
+		"swr": "^2.4.2",
 		"wanakana": "5.3.1"
 	},
 	"devDependencies": {

--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,82 @@
+--- app/prs/6th-anniversary-revenue-report/ImageModal.tsx
++++ app/prs/6th-anniversary-revenue-report/ImageModal.tsx
+@@ -5,22 +5,41 @@
+ import type { StaticImageData } from "next/image";
+ import Image from "next/image";
+-import { useCallback, useEffect, useEffectEvent, useState } from "react";
++import { useCallback, useEffect, useState } from "react";
++import useSWRSubscription from "swr/subscription";
+ import styles from "./page.module.css";
+
+ interface ImageModalProps {
+	src: string | StaticImageData;
+	alt: string;
+ }
+
+ // BEST PRACTICE: Hoist Static JSX Elements (rendering-hoist-jsx.md)
+ const zoomInIconLarge = <ZoomIn size={32} />;
+ const zoomInIconSmall = <ZoomIn size={20} />;
+ const zoomOutIconSmall = <ZoomOut size={20} />;
+ const closeIcon = <X size={24} />;
+
+ // BEST PRACTICE: Deduplicate Global Event Listeners (client-event-listeners.md)
+-const keydownCallbacks = new Set<(e: KeyboardEvent) => void>();
+-let isGlobalKeydownListenerAdded = false;
+-
+-function addGlobalKeydownListener() {
+-	if (typeof window === "undefined" || isGlobalKeydownListenerAdded) return;
+-	window.addEventListener("keydown", (e: KeyboardEvent) => {
+-		for (const cb of keydownCallbacks) {
+-			cb(e);
+-		}
+-	});
+-	isGlobalKeydownListenerAdded = true;
+-}
++const keyCallbacks = new Map<string, Set<() => void>>();
++
++function useKeyboardShortcut(key: string, callback: () => void) {
++	useEffect(() => {
++		if (!keyCallbacks.has(key)) {
++			keyCallbacks.set(key, new Set());
++		}
++		keyCallbacks.get(key)!.add(callback);
++
++		return () => {
++			const set = keyCallbacks.get(key);
++			if (set) {
++				set.delete(callback);
++				if (set.size === 0) {
++					keyCallbacks.delete(key);
++				}
++			}
++		};
++	}, [key, callback]);
++
++	useSWRSubscription("global-keydown", () => {
++		const handler = (e: KeyboardEvent) => {
++			if (keyCallbacks.has(e.key)) {
++				keyCallbacks.get(e.key)!.forEach((cb) => cb());
++			}
++		};
++		window.addEventListener("keydown", handler);
++		return () => window.removeEventListener("keydown", handler);
++	});
++}
+
+ export function ImageModal({ src, alt }: ImageModalProps) {
+@@ -35,16 +54,8 @@
+	}, []);
+
+-	const onEscEvent = useEffectEvent((e: KeyboardEvent) => {
+-		if (e.key === "Escape") closeModal();
+-	});
++	useKeyboardShortcut("Escape", closeModal);
+
+	useEffect(() => {
+-		addGlobalKeydownListener();
+-		keydownCallbacks.add(onEscEvent);
+		return () => {
+-			keydownCallbacks.delete(onEscEvent);
+			document.body.style.overflow = "unset";
+		};
+	}, []);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       react-dom:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
+      swr:
+        specifier: ^2.4.2
+        version: 2.4.2(react@19.2.7)
       wanakana:
         specifier: 5.3.1
         version: 5.3.1
@@ -349,6 +352,10 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -463,6 +470,11 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  swr@2.4.2:
+    resolution: {integrity: sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   third-party-capital@1.0.20:
     resolution: {integrity: sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==}
 
@@ -476,6 +488,11 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   wanakana@5.3.1:
     resolution: {integrity: sha512-OSDqupzTlzl2LGyqTdhcXcl6ezMiFhcUwLBP8YKaBIbMYW1wAwDvupw2T9G9oVaKT9RmaSpyTXjxddFPUcFFIw==}
@@ -674,6 +691,8 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2:
     optional: true
 
@@ -789,6 +808,12 @@ snapshots:
       client-only: 0.0.1
       react: 19.2.7
 
+  swr@2.4.2(react@19.2.7):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.7
+      use-sync-external-store: 1.6.0(react@19.2.7)
+
   third-party-capital@1.0.20: {}
 
   tslib@2.8.1: {}
@@ -796,5 +821,9 @@ snapshots:
   typescript@6.0.3: {}
 
   undici-types@6.21.0: {}
+
+  use-sync-external-store@1.6.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
 
   wanakana@5.3.1: {}


### PR DESCRIPTION
Migrates the manual global event listener deduplication logic in `app/prs/6th-anniversary-revenue-report/ImageModal.tsx` to the `useSWRSubscription` pattern. This ensures global event listeners are correctly shared across multiple component instances while abiding by the documented best practices. Installed `swr` as a dependency.

---
*PR created automatically by Jules for task [1910593414025113618](https://jules.google.com/task/1910593414025113618) started by @hrdtbs*